### PR TITLE
Modifying sensitivity of seekbar, specially useful when the seekbar is inside a RecyclerView

### DIFF
--- a/app/src/main/res/layout/discrete.xml
+++ b/app/src/main/res/layout/discrete.xml
@@ -220,6 +220,23 @@
             app:isb_tick_texts_array="@array/last_next_length_6"
             app:isb_ticks_count="6" />
 
+        <TextView
+            style="@style/subtitle_text_style"
+            android:text="12. Modifying sensitivity of seekbar, specially useful when the seekbar is inside a RecyclerView (longClick, longClickTime (in ms))" />
+
+        <com.warkiz.widget.IndicatorSeekBar
+            android:id="@+id/long_click_drawable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="18dp"
+            app:isb_progress="40"
+            app:isb_show_tick_marks_type="oval"
+            app:isb_show_tick_texts="true"
+            app:isb_tick_texts_array="@array/last_next_length_6"
+            app:isb_ticks_count="6"
+            app:isb_longclick="true"
+            app:isb_longclick_time="500"/>
+
         <include layout="@layout/source_code_link" />
     </LinearLayout>
 

--- a/indicatorseekbar/src/main/java/com/warkiz/widget/Builder.java
+++ b/indicatorseekbar/src/main/java/com/warkiz/widget/Builder.java
@@ -29,6 +29,8 @@ public class Builder {
     boolean userSeekable = true;
     boolean onlyThumbDraggable = false;
     boolean clearPadding = false;
+    boolean longClick = false;
+    int longClickTime = 0;
     //indicator
     int showIndicatorType = IndicatorType.ROUNDED_RECTANGLE;
     int indicatorColor = Color.parseColor("#FF4081");
@@ -160,6 +162,28 @@ public class Builder {
      */
     public Builder clearPadding(boolean clearPadding) {
         this.clearPadding = clearPadding;
+        return this;
+    }
+
+    /**
+     * seek bar will respond only on longClick
+     *
+     * @param longClick true to set longClick behaviour
+     * @return Builder
+     */
+    public Builder longClick(boolean longClick){
+        this.longClick = longClick;
+        return this;
+    }
+
+    /**
+     * seek bar will respond on longClick after a time expressed in ms
+     *
+     * @param longClickTime time (in ms) before to respond
+     * @return Builder
+     */
+    public Builder longClickTime(int longClickTime){
+        this.longClickTime = longClickTime;
         return this;
     }
 

--- a/indicatorseekbar/src/main/java/com/warkiz/widget/IndicatorSeekBar.java
+++ b/indicatorseekbar/src/main/java/com/warkiz/widget/IndicatorSeekBar.java
@@ -32,6 +32,7 @@ import android.view.animation.Animation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.util.Date;
 
 /**
  * created by zhuangguangquan on 2017/9/1
@@ -74,6 +75,10 @@ public class IndicatorSeekBar extends View {
     private boolean mSeekSmoothly;//seek continuously
     private float[] mProgressArr;//save the progress which at tickMark position.
     private boolean mR2L;//right to left,compat local problem.
+    private boolean mLongClick;//true if seekbar responds on longClick
+    private int mLongClickTime;//time (in ms) passed before responds onlongClick
+    private long startTime;
+    private long endTime;
     //tick texts
     private boolean mShowTickText;//the palace where the tick text show .
     private boolean mShowBothTickTextsOnly;//show the tick texts on the both ends of seek bar before.
@@ -187,6 +192,8 @@ public class IndicatorSeekBar extends View {
         mOnlyThumbDraggable = ta.getBoolean(R.styleable.IndicatorSeekBar_isb_only_thumb_draggable, builder.onlyThumbDraggable);
         mSeekSmoothly = ta.getBoolean(R.styleable.IndicatorSeekBar_isb_seek_smoothly, builder.seekSmoothly);
         mR2L = ta.getBoolean(R.styleable.IndicatorSeekBar_isb_r2l, builder.r2l);
+        mLongClick = ta.getBoolean(R.styleable.IndicatorSeekBar_isb_longclick, builder.longClick);
+        mLongClickTime = ta.getInteger(R.styleable.IndicatorSeekBar_isb_longclick_time, builder.longClickTime);
         //track
         mBackgroundTrackSize = ta.getDimensionPixelSize(R.styleable.IndicatorSeekBar_isb_track_background_size, builder.trackBackgroundSize);
         mProgressTrackSize = ta.getDimensionPixelSize(R.styleable.IndicatorSeekBar_isb_track_progress_size, builder.trackProgressSize);
@@ -1205,18 +1212,43 @@ public class IndicatorSeekBar extends View {
                     if (mSeekChangeListener != null) {
                         mSeekChangeListener.onStartTrackingTouch(this);
                     }
-                    refreshSeekBar(event);
+                    if(!mLongClick) {
+                        refreshSeekBar(event);
+                    }
+                    else{
+                        startTime = event.getEventTime();
+                    }
                     return true;
                 }
                 break;
             case MotionEvent.ACTION_MOVE:
-                refreshSeekBar(event);
+                if(mLongClick) {
+                    endTime = event.getEventTime();
+                    if (endTime - startTime > mLongClickTime) {
+                        refreshSeekBar(event);
+                    }
+                }
+                else{
+                    refreshSeekBar(event);
+                }
                 break;
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
                 mIsTouching = false;
-                if (mSeekChangeListener != null) {
-                    mSeekChangeListener.onStopTrackingTouch(this);
+
+                if(mLongClick) {
+                    endTime = event.getEventTime();
+                    if (endTime - startTime > mLongClickTime) {
+                        refreshSeekBar(event);
+                        if (mSeekChangeListener != null) {
+                            mSeekChangeListener.onStopTrackingTouch(this);
+                        }
+                    }
+                }
+                else{
+                    if (mSeekChangeListener != null) {
+                        mSeekChangeListener.onStopTrackingTouch(this);
+                    }
                 }
                 if (!autoAdjustThumb()) {
                     invalidate();

--- a/indicatorseekbar/src/main/res/values/attr.xml
+++ b/indicatorseekbar/src/main/res/values/attr.xml
@@ -12,6 +12,8 @@
         <attr name="isb_user_seekable" format="boolean" /><!--prevent user from seeking,only can be change thumb location by setProgress(), default false-->
         <attr name="isb_clear_default_padding" format="boolean" /><!-- set seekBar's leftPadding&rightPadding to zero, default false, default padding is 16dp-->
         <attr name="isb_only_thumb_draggable" format="boolean" /><!--user change the thumb's location by touching thumb/touching track,true for touching track to seek. false for touching thumb; default false-->
+        <attr name="isb_longclick" format="boolean" />
+        <attr name="isb_longclick_time" format="integer" />
         //indicator
         <attr name="isb_show_indicator"><!-- the type of indicator, default rectangle_rounded_corner/0.-->
             <enum name="none" value="0" />


### PR DESCRIPTION
Hi, I found useful this behaviour in order to improve the user experience when you have a seekbar in every item of a RecyclerView. Sometimes if you fail scrolling you can change the progress of a seekbar accidentally.

Changes in my branch:
- Modifying sensitivity of seekbar, specially useful when the seekbar is inside a RecyclerView. 
- Added two new parameters longClick, longClickTime expressed in ms and modified onTouchEvent in IndicatorSeekBar. 
- Also created an example of the use in sample app

If you find useful this you could add it to the project!
Thanks in advance.
