### PR TITLE
Horizontal and vertical tolerance added for touch and drag gap

### DIFF
--- a/app/src/main/res/layout/custom_indicator.xml
+++ b/app/src/main/res/layout/custom_indicator.xml
@@ -61,11 +61,20 @@
         <com.warkiz.widget.IndicatorSeekBar
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingTop="30dp"
+            android:paddingBottom="30dp"
             app:isb_indicator_content_layout="@layout/custom_indicator_oval"
+            app:isb_max="5"
+            app:isb_min="1"
+            app:isb_only_thumb_draggable="false"
             app:isb_progress="75"
             app:isb_show_indicator="custom"
             app:isb_show_tick_marks_type="divider"
-            app:isb_ticks_count="6" />
+            app:isb_thumb_color="#3cd200"
+            app:isb_thumb_size="20dp"
+            app:isb_ticks_count="5"
+            app:isb_track_progress_size="4dp"
+            app:isb_vertical_touch_gap="30dp" />
 
         <TextView
             style="@style/subtitle_text_style"

--- a/indicatorseekbar/src/main/java/com/warkiz/widget/IndicatorSeekBar.java
+++ b/indicatorseekbar/src/main/java/com/warkiz/widget/IndicatorSeekBar.java
@@ -53,7 +53,8 @@ public class IndicatorSeekBar extends View {
     private Rect mRect;
     private float mCustomDrawableMaxHeight;//the max height for custom drawable
     private float lastProgress;
-    private float mFaultTolerance = -1;//the tolerance for user seek bar touching
+    private float mFaultToleranceHorizontal = -1;//the tolerance for user seek bar touching horizontally
+    private float mFaultToleranceVertical = -1;//the tolerance for user seek bar touching vertically
     private float mScreenWidth = -1;
     private boolean mClearPadding;
     private SeekParams mSeekParams;//save the params when seeking change.
@@ -193,6 +194,8 @@ public class IndicatorSeekBar extends View {
         mOnlyThumbDraggable = ta.getBoolean(R.styleable.IndicatorSeekBar_isb_only_thumb_draggable, builder.onlyThumbDraggable);
         mSeekSmoothly = ta.getBoolean(R.styleable.IndicatorSeekBar_isb_seek_smoothly, builder.seekSmoothly);
         mR2L = ta.getBoolean(R.styleable.IndicatorSeekBar_isb_r2l, builder.r2l);
+        mFaultToleranceHorizontal = ta.getDimensionPixelSize(R.styleable.IndicatorSeekBar_isb_horizontal_touch_gap, SizeUtils.dp2px(context, 5));
+        mFaultToleranceVertical = ta.getDimensionPixelSize(R.styleable.IndicatorSeekBar_isb_vertical_touch_gap, SizeUtils.dp2px(context, 5));
         //track
         mBackgroundTrackSize = ta.getDimensionPixelSize(R.styleable.IndicatorSeekBar_isb_track_background_size, builder.trackBackgroundSize);
         mProgressTrackSize = ta.getDimensionPixelSize(R.styleable.IndicatorSeekBar_isb_track_progress_size, builder.trackProgressSize);
@@ -1278,11 +1281,14 @@ public class IndicatorSeekBar extends View {
     }
 
     private boolean isTouchSeekBar(float mX, float mY) {
-        if (mFaultTolerance == -1) {
-            mFaultTolerance = SizeUtils.dp2px(mContext, 5);
+        if (mFaultToleranceVertical == -1) {
+            mFaultToleranceVertical = SizeUtils.dp2px(mContext, 5);
         }
-        boolean inWidthRange = mX >= (mPaddingLeft - 2 * mFaultTolerance) && mX <= (mMeasuredWidth - mPaddingRight + 2 * mFaultTolerance);
-        boolean inHeightRange = mY >= mProgressTrack.top - mThumbTouchRadius - mFaultTolerance && mY <= mProgressTrack.top + mThumbTouchRadius + mFaultTolerance;
+        if (mFaultToleranceHorizontal == -1) {
+            mFaultToleranceHorizontal = SizeUtils.dp2px(mContext, 5);
+        }
+        boolean inWidthRange = mX >= (mPaddingLeft - 2 * mFaultToleranceHorizontal) && mX <= (mMeasuredWidth - mPaddingRight + 2 * mFaultToleranceHorizontal);
+        boolean inHeightRange = mY >= mProgressTrack.top - mThumbTouchRadius - mFaultToleranceVertical && mY <= mProgressTrack.top + mThumbTouchRadius + mFaultToleranceVertical;
         return inWidthRange && inHeightRange;
     }
 

--- a/indicatorseekbar/src/main/res/values/attr.xml
+++ b/indicatorseekbar/src/main/res/values/attr.xml
@@ -9,6 +9,8 @@
         <attr name="isb_seek_smoothly" format="boolean" /><!--true to seek smoothly when has ticks, default false-->
         <attr name="isb_r2l" format="boolean" /><!--compat app local change,like arabic local, default false-->
         <attr name="isb_ticks_count" format="integer" /><!--seekBar's ticks count, default zero-->
+        <attr name="isb_horizontal_touch_gap" format="dimension|reference" /><!--seekBar's ticks count, default zero-->
+        <attr name="isb_vertical_touch_gap" format="dimension|reference" /><!--seekBar's ticks count, default zero-->
         <attr name="isb_user_seekable" format="boolean" /><!--prevent user from seeking,only can be change thumb location by setProgress(), default false-->
         <attr name="isb_clear_default_padding" format="boolean" /><!-- set seekBar's leftPadding&rightPadding to zero, default false, default padding is 16dp-->
         <attr name="isb_only_thumb_draggable" format="boolean" /><!--user change the thumb's location by touching thumb/touching track,true for touching track to seek. false for touching thumb; default false-->


### PR DESCRIPTION
Add padding to seekbar, then you can use `isb_vertical_touch_gap`and `isb_horizontal_touch_gap ` to set bigger area for user to touch and drag thumb.

Example:
```
 <com.warkiz.widget.IndicatorSeekBar
            android:layout_width="match_parent"
            android:layout_height="wrap_content"
            android:paddingTop="30dp"
            android:paddingBottom="30dp"
            app:isb_max="5"
            app:isb_min="1"
            app:isb_only_thumb_draggable="false"
            app:isb_vertical_touch_gap="30dp" />
```