### PR TITLE
修复未按设定进度赋值问题

### DIFF
--- a/indicatorseekbar/src/main/java/com/warkiz/widget/IndicatorSeekBar.java
+++ b/indicatorseekbar/src/main/java/com/warkiz/widget/IndicatorSeekBar.java
@@ -393,7 +393,7 @@ public class IndicatorSeekBar extends View {
         initTextsArray();
         //adjust thumb auto,so find out the closest progress in the mProgressArr array and replace it.
         //it is not necessary to adjust thumb while count is less than 2.
-        if (mTicksCount > 2) {
+        if ((!mSeekSmoothly) && mTicksCount > 2) {
             mProgress = mProgressArr[getClosestIndex()];
             lastProgress = mProgress;
         }


### PR DESCRIPTION
修复无论isb_thumb_adjust_auto=true，只要isb_ticks_count>2不论是xml还是java中为seekbar设置progress都不会生效，只会按就近的ticks的值进行四舍五入的问题。